### PR TITLE
Load git_repository in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 # For packaging python scripts.
 git_repository(
     name = "subpar",
-    remote = "https://github.com/google/subpar",
     commit = "edb8409041b521959b6ed4b7412c0eec59d4af78",
+    remote = "https://github.com/google/subpar",
 )


### PR DESCRIPTION
This is required with newer versions of bazel. This also runs buildifier
on this file.