### PR TITLE
Add platform's usr/lib directory to UI tests

### DIFF
--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -476,8 +476,10 @@ class XctestRunFactory(object):
         'DYLD_FRAMEWORK_PATH':
             '__TESTROOT__:__PLATFORMS__/%s.platform/Developer/'
             'Library/Frameworks' % platform_name,
-        'DYLD_LIBRARY_PATH': '__TESTROOT__:__PLATFORMS__/%s.platform/Developer/'
-                             'Library/Frameworks' % platform_name
+        'DYLD_LIBRARY_PATH':
+            '__TESTROOT__:__PLATFORMS__/{platform}.platform/Developer/usr/lib:'
+            '__PLATFORMS__/{platform}.platform/Developer/Library/Frameworks'
+            .format(platform=platform_name)
     }
     self._xctestrun_dict = {
         'IsUITestBundle': True,


### PR DESCRIPTION
With Xcode 11 there's a new module called libXCTestSwiftSupport.dylib
that is required for running UI tests with Swift. This library is passed
to the Swift compiler / the linker with
https://github.com/bazelbuild/rules_swift/pull/300 but it also needs to
be accessible at runtime. Xcode copies this into the runner app's
Frameworks directory, but this is good enough and a bit simpler.