### PR TITLE
Rewrite imports for local builds

### DIFF
--- a/shared/bundle_util.py
+++ b/shared/bundle_util.py
@@ -19,8 +19,8 @@ import os
 import subprocess
 import tempfile
 
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import plist_util
+from shared import ios_errors
+from shared import plist_util
 
 
 def ExtractApp(compressed_app_path, working_dir):

--- a/shared/plist_util.py
+++ b/shared/plist_util.py
@@ -20,7 +20,7 @@ import plistlib
 import subprocess
 import xml.parsers.expat
 
-from xctestrunner.shared import ios_errors
+from shared import ios_errors
 try:
   import biplist
 except ImportError:

--- a/shared/provisioning_profile.py
+++ b/shared/provisioning_profile.py
@@ -21,8 +21,8 @@ import subprocess
 import tempfile
 import uuid
 
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import plist_util
+from shared import ios_errors
+from shared import plist_util
 
 
 class ProvisiongProfile(object):

--- a/simulator_control/simtype_profile.py
+++ b/simulator_control/simtype_profile.py
@@ -16,10 +16,10 @@
 
 import os
 
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import plist_util
-from xctestrunner.shared import xcode_info_util
+from shared import ios_constants
+from shared import ios_errors
+from shared import plist_util
+from shared import xcode_info_util
 
 
 class SimTypeProfile(object):

--- a/simulator_control/simulator_util.py
+++ b/simulator_control/simulator_util.py
@@ -23,11 +23,11 @@ import shutil
 import subprocess
 import time
 
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import plist_util
-from xctestrunner.shared import xcode_info_util
-from xctestrunner.simulator_control import simtype_profile
+from shared import ios_constants
+from shared import ios_errors
+from shared import plist_util
+from shared import xcode_info_util
+from simulator_control import simtype_profile
 
 _SIMULATOR_STATES_MAPPING = {
     0: ios_constants.SimState.CREATING,

--- a/test_runner/dummy_project.py
+++ b/test_runner/dummy_project.py
@@ -26,13 +26,13 @@ import subprocess
 import tempfile
 import xml.etree.ElementTree as ET
 
-from xctestrunner.shared import bundle_util
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import plist_util
-from xctestrunner.shared import provisioning_profile
-from xctestrunner.shared import xcode_info_util
-from xctestrunner.test_runner import xcodebuild_test_executor
+from shared import bundle_util
+from shared import ios_constants
+from shared import ios_errors
+from shared import plist_util
+from shared import provisioning_profile
+from shared import xcode_info_util
+from test_runner import xcodebuild_test_executor
 
 
 _DEFAULT_PERMS = 0o0777

--- a/test_runner/ios_test_runner.py
+++ b/test_runner/ios_test_runner.py
@@ -25,12 +25,12 @@ import logging
 import subprocess
 import sys
 
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import xcode_info_util
-from xctestrunner.simulator_control import simulator_util
-from xctestrunner.test_runner import runner_exit_codes
-from xctestrunner.test_runner import xctest_session
+from shared import ios_constants
+from shared import ios_errors
+from shared import xcode_info_util
+from simulator_control import simulator_util
+from test_runner import runner_exit_codes
+from test_runner import xctest_session
 
 _XCTESTRUN_HELP = (
     """The path of the xctestrun file.

--- a/test_runner/logic_test_util.py
+++ b/test_runner/logic_test_util.py
@@ -17,9 +17,9 @@
 import subprocess
 import sys
 
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import xcode_info_util
-from xctestrunner.test_runner import runner_exit_codes
+from shared import ios_constants
+from shared import xcode_info_util
+from test_runner import runner_exit_codes
 
 _SIMCTL_ENV_VAR_PREFIX = 'SIMCTL_CHILD_'
 

--- a/test_runner/test_summaries_util.py
+++ b/test_runner/test_summaries_util.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import tempfile
 
-from xctestrunner.shared import plist_util
+from shared import plist_util
 
 
 def GetTestSummariesPaths(derived_data_dir):

--- a/test_runner/xcodebuild_test_executor.py
+++ b/test_runner/xcodebuild_test_executor.py
@@ -25,11 +25,11 @@ import sys
 import threading
 import time
 
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import xcode_info_util
-from xctestrunner.simulator_control import simulator_util
-from xctestrunner.test_runner import runner_exit_codes
+from shared import ios_constants
+from shared import ios_errors
+from shared import xcode_info_util
+from simulator_control import simulator_util
+from test_runner import runner_exit_codes
 
 
 _XCODEBUILD_TEST_STARTUP_TIMEOUT_SEC = 150

--- a/test_runner/xctest_session.py
+++ b/test_runner/xctest_session.py
@@ -20,15 +20,15 @@ import shutil
 import subprocess
 import tempfile
 
-from xctestrunner.shared import bundle_util
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import xcode_info_util
-from xctestrunner.test_runner import dummy_project
-from xctestrunner.test_runner import logic_test_util
-from xctestrunner.test_runner import runner_exit_codes
-from xctestrunner.test_runner import test_summaries_util
-from xctestrunner.test_runner import xctestrun
+from shared import bundle_util
+from shared import ios_constants
+from shared import ios_errors
+from shared import xcode_info_util
+from test_runner import dummy_project
+from test_runner import logic_test_util
+from test_runner import runner_exit_codes
+from test_runner import test_summaries_util
+from test_runner import xctestrun
 
 
 class XctestSession(object):

--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -19,12 +19,12 @@ import os
 import shutil
 import tempfile
 
-from xctestrunner.shared import bundle_util
-from xctestrunner.shared import ios_constants
-from xctestrunner.shared import ios_errors
-from xctestrunner.shared import plist_util
-from xctestrunner.shared import xcode_info_util
-from xctestrunner.test_runner import xcodebuild_test_executor
+from shared import bundle_util
+from shared import ios_constants
+from shared import ios_errors
+from shared import plist_util
+from shared import xcode_info_util
+from test_runner import xcodebuild_test_executor
 
 
 TESTROOT_RELATIVE_PATH = '__TESTROOT__'


### PR DESCRIPTION
Without this if you build this yourself you get this error when you try
and run it:

```
File "./ios_test_runner.par/__main__.py", line 33, in <module>
  ImportError: No module named xctestrunner.shared
```