### PR TITLE
set python version to PY2

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,4 +27,5 @@ par_binary(
         ':simulator',
     ],
     data = glob(['test_runner/TestProject/**']),
+    python_version = 'PY2',
 )


### PR DESCRIPTION
**In order to build this stuff:**

Prerequisite: merge commit in https://github.com/google/xctestrunner/pull/8
Python 2.7 installed
XCode 11 installed with python 3.x


**Build**: Bazel build ios_test_runner.par

**Bazel xctest run:**
```
Traceback (most recent call last):
File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
"main", mod_spec)
File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
exec(code, run_globals)
File "../xctestrunner/file/downloaded/main.py", line 313, in <module>
File "../xctestrunner/file/downloaded/main.py", line 307, in main
File "../xctestrunner/file/downloaded/main.py", line 215, in _SimulatorTest
File "../xctestrunner/file/downloaded/main.py", line 156, in _RunSimulatorTest
File "../xctestrunner/file/downloaded/main/test_runner/xctest_session.py", line 139, in Prepare
File "../xctestrunner/file/downloaded/main/test_runner/xctest_session.py", line 368, in _FinalizeTestType
File "../xctestrunner/file/downloaded/main/test_runner/xctest_session.py", line 405, in _DetectTestType
TypeError: a bytes-like object is required, not 'str'
```
**Root cause**: some code like subprocess.check_output return binary in python3, not string as in python2. 

**To fix**: add python_version = 'PY2' into the BUILD file to explicitly build for python 2, then everything works. Passing '--python_version PY2' to 'Bazel build ios_test_runner.par' command doesn't seem to work for me.
