### PR TITLE
Fix failure to launch tests with Xcode 11 on pre-iOS 12.2 sims running Swift tests that reference ObjC APIs with no bridged Foundation types

### DIFF
--- a/shared/xcode_info_util.py
+++ b/shared/xcode_info_util.py
@@ -17,6 +17,7 @@
 import os
 import subprocess
 
+from shared import ios_constants
 
 _xcode_version_number = None
 
@@ -24,6 +25,15 @@ _xcode_version_number = None
 def GetXcodeDeveloperPath():
   """Gets the active developer path of Xcode command line tools."""
   return subprocess.check_output(('xcode-select', '-p')).strip()
+
+
+def GetSwift5FallbackLibsDir():
+  relativePath = "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0"
+  swiftLibsDir = os.path.join(GetXcodeDeveloperPath(), relativePath)
+  swiftLibPlatformDir = os.path.join(swiftLibsDir, ios_constants.SDK.IPHONESIMULATOR)
+  if os.path.exists(swiftLibPlatformDir):
+    return swiftLibPlatformDir
+  return None
 
 
 def GetXcodeVersionNumber():

--- a/shared/xcode_info_util.py
+++ b/shared/xcode_info_util.py
@@ -27,6 +27,12 @@ def GetXcodeDeveloperPath():
   return subprocess.check_output(('xcode-select', '-p')).strip()
 
 
+# Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
+# libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
+# run on simulators running iOS 12.1 or lower. To fix this bug, we need to provide explicit
+# fallbacks to the correct Swift dylibs that have been packaged with Xcode. This method returns the
+# path to that fallback directory.
+# See https://github.com/bazelbuild/rules_apple/issues/684 for context.
 def GetSwift5FallbackLibsDir():
   relativePath = "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0"
   swiftLibsDir = os.path.join(GetXcodeDeveloperPath(), relativePath)

--- a/test_runner/logic_test_util.py
+++ b/test_runner/logic_test_util.py
@@ -49,11 +49,10 @@ def RunLogicTestOnSim(
       simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + key] = env_vars[key]
   simctl_env_vars['NSUnbufferedIO'] = 'YES'
 
-  # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
-  # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
-  # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
-  # the correct Swift dylibs that have been packaged with Xcode.
-  # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+  # Fixes failures for unit test targets that depend on Swift libraries when running with Xcode 11
+  # on pre-iOS 12.2 simulators.
+  # Example failure message this resolves: "The bundle couldn’t be loaded because it is damaged
+  # or missing necessary resources."
   swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
   if swift5FallbackLibsDir:
     simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + "DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir

--- a/test_runner/logic_test_util.py
+++ b/test_runner/logic_test_util.py
@@ -48,6 +48,16 @@ def RunLogicTestOnSim(
     for key in env_vars:
       simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + key] = env_vars[key]
   simctl_env_vars['NSUnbufferedIO'] = 'YES'
+
+  # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
+  # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
+  # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
+  # the correct Swift dylibs that have been packaged with Xcode.
+  # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+  swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
+  if swift5FallbackLibsDir:
+    simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + "DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir
+
   command = [
       'xcrun', 'simctl', 'spawn', '-s', sim_id,
       xcode_info_util.GetXctestToolPath(ios_constants.SDK.IPHONESIMULATOR)]

--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -475,6 +475,15 @@ class XctestRunFactory(object):
                                    developer=developer_path),
         'DYLD_LIBRARY_PATH': '__TESTROOT__:%s/usr/lib' % developer_path
     }
+    # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
+    # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
+    # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
+    # the correct Swift dylibs that have been packaged with Xcode.
+    # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+    swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
+    if swift5FallbackLibsDir:
+      test_envs["DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir
+
     self._xctestrun_dict = {
         'IsUITestBundle': True,
         'SystemAttachmentLifetime': 'keepNever',
@@ -613,6 +622,15 @@ class XctestRunFactory(object):
         'DYLD_INSERT_LIBRARIES': dyld_insert_libs,
         'DYLD_LIBRARY_PATH': '__TESTROOT__:%s/usr/lib:' % developer_path
     }
+    # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
+    # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
+    # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
+    # the correct Swift dylibs that have been packaged with Xcode.
+    # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+    swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
+    if swift5FallbackLibsDir:
+      test_envs["DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir
+
     self._xctestrun_dict = {
         'TestHostPath': self._app_under_test_dir,
         'TestBundlePath': self._test_bundle_dir,
@@ -633,6 +651,15 @@ class XctestRunFactory(object):
         'DYLD_FRAMEWORK_PATH': dyld_framework_path,
         'DYLD_LIBRARY_PATH': dyld_framework_path
     }
+    # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
+    # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
+    # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
+    # the correct Swift dylibs that have been packaged with Xcode.
+    # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+    swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
+    if swift5FallbackLibsDir:
+      test_envs["DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir
+
     self._xctestrun_dict = {
         'TestBundlePath': self._test_bundle_dir,
         'TestHostPath': xcode_info_util.GetXctestToolPath(self._sdk),

--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -475,11 +475,11 @@ class XctestRunFactory(object):
                                    developer=developer_path),
         'DYLD_LIBRARY_PATH': '__TESTROOT__:%s/usr/lib' % developer_path
     }
-    # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
-    # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
-    # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
-    # the correct Swift dylibs that have been packaged with Xcode.
-    # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+
+    # Fixes failures for UI test targets that depend on Swift libraries when running with Xcode 11
+    # on pre-iOS 12.2 simulators.
+    # Example failure message this resolves: "The bundle couldn’t be loaded because it is damaged
+    # or missing necessary resources."
     swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
     if swift5FallbackLibsDir:
       test_envs["DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir
@@ -622,11 +622,11 @@ class XctestRunFactory(object):
         'DYLD_INSERT_LIBRARIES': dyld_insert_libs,
         'DYLD_LIBRARY_PATH': '__TESTROOT__:%s/usr/lib:' % developer_path
     }
-    # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
-    # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
-    # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
-    # the correct Swift dylibs that have been packaged with Xcode.
-    # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+
+    # Fixes failures for test targets that depend on Swift libraries when running with Xcode 11
+    # on pre-iOS 12.2 simulators.
+    # Example failure message this resolves: "The bundle couldn’t be loaded because it is damaged
+    # or missing necessary resources."
     swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
     if swift5FallbackLibsDir:
       test_envs["DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir
@@ -651,11 +651,11 @@ class XctestRunFactory(object):
         'DYLD_FRAMEWORK_PATH': dyld_framework_path,
         'DYLD_LIBRARY_PATH': dyld_framework_path
     }
-    # Xcode 11+'s Swift dylibs are configured in a way that does not allow them to load the correct
-    # libswiftFoundation.dylib file from libXCTestSwiftSupport.dylib. This bug only affects tests that
-    # run on simulators running iOS 12.1 or lower. To fix this bug, we provide an explicit fallback to
-    # the correct Swift dylibs that have been packaged with Xcode.
-    # See https://github.com/bazelbuild/rules_apple/issues/684 for context.
+
+    # Fixes failures for unit test targets that depend on Swift libraries when running with Xcode 11
+    # on pre-iOS 12.2 simulators.
+    # Example failure message this resolves: "The bundle couldn’t be loaded because it is damaged
+    # or missing necessary resources."
     swift5FallbackLibsDir = xcode_info_util.GetSwift5FallbackLibsDir()
     if swift5FallbackLibsDir:
       test_envs["DYLD_FALLBACK_LIBRARY_PATH"] = swift5FallbackLibsDir


### PR DESCRIPTION
This PR fixes an edge case that occurs when the following conditions are met:

- There is either a `ios_unit_test` or `ios_ui_test` target, `//:test`.
- `//:test`'s `ios_test_runner` targets iOS 12.1 or earlier.
- `//:test` depends on a `swift_library` target, `//:test_sources`, which has a `Tests.swift` file.
- `//:test_sources` depends on an `objc_library` target, `//:lib`, which has a `Lib.h` and `Lib.m` file.
- `//:test_sources` does not reference any API exposed by `//:lib` that makes use of a bridged Foundation type (e.g. NSArray, NSDictionary, NSSet).
- bazel test `//:test` is ran with at least Xcode 11.0

Example repro environment: https://github.com/jverkoey/xctestrunner-13-repro/tree/broken

If the conditions above are met, then the test will fail to run due to the following error:

```
Executing tests from //:UnitTests_IPHONE_7_PLUS_IN_10_3
-----------------------------------------------------------------------------
2019-12-30 15:26:44,866 Will consider the test as test type logic_test to run.
2019-12-30 15:26:51,569 Failed to import biplist module. Will use tool /usr/libexec/PlistBuddy to handle the binary format plist.
2019-12-30 15:26:51,574 Failed to import biplist module. Will use tool /usr/libexec/PlistBuddy to handle the binary format plist.
2019-12-30 15:26:51,578 Failed to import biplist module. Will use tool /usr/libexec/PlistBuddy to handle the binary format plist.
2019-12-30 15:26:51,582 Failed to import biplist module. Will use tool /usr/libexec/PlistBuddy to handle the binary format plist.
2019-12-30 15:26:51,595 Failed to import biplist module. Will use tool /usr/libexec/PlistBuddy to handle the binary format plist.
2019-12-30 15:26:51,614 Creating a new simulator:
Name: New-iPhone 7 Plus-10.3
OS: iOS 10.3
Type: iPhone 7 Plus
2019-12-30 15:26:55,099 Created new simulator 5E47303C-01D8-4CE5-BB1F-2DB29EDB0594.
2019-12-30 10:26:59.773 xctest[27261:3328048] The bundle “UnitTests” couldn’t be loaded because it is damaged or missing necessary resources. Try reinstalling the bundle.
2019-12-30 10:26:59.775 xctest[27261:3328048] (dlopen_preflight(/var/folders/nf/gl8gqkdd6fg98rjd9rgzkt70002gv0/T/test_runner_work_dir.hdY99T/UnitTests/UnitTests.xctest/UnitTests): Library not loaded: @rpath/libswiftCoreGraphics.dylib
  Referenced from: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib
  Reason: no suitable image found.  Did find:
  /usr/lib/swift/libswiftCoreGraphics.dylib: mach-o, but not built for iOS simulator
  /usr/lib/swift/libswiftCoreGraphics.dylib: mach-o, but not built for iOS simulator)
2019-12-30 15:26:59,783 Deleting simulator 5E47303C-01D8-4CE5-BB1F-2DB29EDB0594 asynchronously.
2019-12-30 15:26:59,787 Done.
```

## Manual testing

```bash
git clone https://github.com/jverkoey/xctestrunner-13-repro.git
cd xctestrunner-13-repro

git checkout broken
bazel test //...
# Confirm that the iOS 10.3 and 11.4 tests fail to run for both unit and UI

git checkout working
bazel test //...
# Confirm that the tests succeed
```

Closes https://github.com/bazelbuild/rules_apple/issues/684

## Notes

This change has been ported from the internal change, [cl/280014348](http://cl/280014348).

To test this PR I needed to patch in https://github.com/google/xctestrunner/pull/8 to my fork of this repo because I was otherwise unable to build a usable `.par`.