### PR TITLE
Fix python2 interpreter

### DIFF
--- a/xctestrunner/BUILD
+++ b/xctestrunner/BUILD
@@ -3,28 +3,33 @@ package(default_visibility = ["//visibility:public"])
 load("@subpar//:subpar.bzl", "par_binary")
 
 py_library(
-    name = 'shared',
-    srcs = glob(['shared/*.py']),
+    name = "shared",
+    srcs = glob(["shared/*.py"]),
 )
 
 py_library(
-    name = 'simulator',
-    srcs = glob(['simulator_control/*.py']),
+    name = "simulator",
+    srcs = glob(["simulator_control/*.py"]),
     deps = [
-        ':shared',
+        ":shared",
     ],
 )
 
 par_binary(
-    name = 'ios_test_runner',
+    name = "ios_test_runner",
     srcs = glob(
-        ['test_runner/*.py'],
-        exclude = ['test_runner/TestProject/**']
+        ["test_runner/*.py"],
+        exclude = ["test_runner/TestProject/**"],
     ),
-    main = 'test_runner/ios_test_runner.py',
-    deps = [
-        ':shared',
-        ':simulator',
+    compiler_args = [
+        "--interpreter",
+        "/usr/bin/python2.7",
     ],
-    data = glob(['test_runner/TestProject/**']),
+    data = glob(["test_runner/TestProject/**"]),
+    main = "test_runner/ios_test_runner.py",
+    python_version = "PY2",
+    deps = [
+        ":shared",
+        ":simulator",
+    ],
 )


### PR DESCRIPTION
By default when specifying PY2 as the `python_version` the shebang in
the produced parfile is `/usr/bin/env python2` which doesn't exist on
macOS (unless users have created it).

This fix forces the shebang to be `/usr/bin/python2.7` which exists on
all recent macOS versions. Once this project is converted to python3,
we should change this to `/usr/bin/python3` instead.

Fixes https://github.com/google/xctestrunner/issues/18