### PR TITLE
Pass DEVELOPER_DIR to `xcrun simctl spawn`

### DIFF
--- a/xctestrunner/test_runner/logic_test_util.py
+++ b/xctestrunner/test_runner/logic_test_util.py
@@ -14,6 +14,7 @@
 
 """The helper classes to run logic test."""
 
+import os
 import subprocess
 import sys
 
@@ -62,6 +63,11 @@ def RunLogicTestOnSim(sim_id,
       version_util.GetVersionNumber(os_version) < 1220):
     key = _SIMCTL_ENV_VAR_PREFIX + 'DYLD_FALLBACK_LIBRARY_PATH'
     simctl_env_vars[key] = xcode_info_util.GetSwift5FallbackLibsDir()
+  # We need to set the DEVELOPER_DIR to ensure xcrun works correctly
+  developer_dir = os.environ.get('DEVELOPER_DIR')
+  if developer_dir:
+    simctl_env_vars['DEVELOPER_DIR'] = developer_dir
+
   command = [
       'xcrun', 'simctl', 'spawn', '-s', sim_id,
       xcode_info_util.GetXctestToolPath(ios_constants.SDK.IPHONESIMULATOR)]


### PR DESCRIPTION
In all cases, except `xcrun simctl spawn`, we inherit `os.environ` when running commands. This change passes through DEVELOPER_DIR to allow xcrun to select the correct simctl.

Without this change, the only way to get the correct simulator selected, is to use `xcode-select`, which is a system level change, and prone to errors. With this change, one can run `env DEVELOPER_DIR=/Applications/Xcode-12.0b1.app/Contents/Developer bazel test --test_env=DEVELOPER_DIR -- //TestTarget` and the correct simulator will be created and used.