### PR TITLE
Add xcresult bundle collection

### DIFF
--- a/xctestrunner/shared/ios_constants.py
+++ b/xctestrunner/shared/ios_constants.py
@@ -67,6 +67,9 @@ Available keys for the json:
     In xctest, the functionality is the same as "args".
     In xcuitest, the process of app under test is different with the
     process of test.
+  keep_xcresult_data: bool
+    Whether or not to keep the xcresult bundle produced by the test run
+    in the output_dir.
   tests_to_run : array
     The specific test classes or test methods to run. Each item should be
     string and its format is Test-Class-Name[/Test-Method-Name]. It is supported

--- a/xctestrunner/test_runner/xctest_session.py
+++ b/xctestrunner/test_runner/xctest_session.py
@@ -59,6 +59,7 @@ class XctestSession(object):
     self._destination_timeout_sec = None
     self._xctestrun_obj = None
     self._prepared = False
+    self._keep_xcresult_data = True
     # The following fields are only for Logic Test.
     self._logic_test_bundle = None
     self._logic_test_env_vars = None
@@ -159,6 +160,7 @@ class XctestSession(object):
           'XctestSession.Prepare first.')
     if not launch_options:
       return
+    self._keep_xcresult_data = launch_options.get('keep_xcresult_data', True)
     self._startup_timeout_sec = launch_options.get('startup_timeout_sec')
     self._destination_timeout_sec = launch_options.get(
         'destination_timeout_sec')
@@ -214,6 +216,8 @@ class XctestSession(object):
       # The xcresult only contains raw data in Xcode 11 or later.
       if xcode_info_util.GetXcodeVersionNumber() >= 1100:
         xcresult_util.ExposeDiagnosticsRef(result_bundle_path, test_log_dir)
+        if not self._keep_xcresult_data:
+          shutil.rmtree(result_bundle_path)
       return exit_code
     elif self._logic_test_bundle:
       return logic_test_util.RunLogicTestOnSim(

--- a/xctestrunner/test_runner/xctest_session.py
+++ b/xctestrunner/test_runner/xctest_session.py
@@ -14,7 +14,6 @@
 
 """The module to run XCTEST based tests."""
 
-import glob
 import logging
 import os
 import shutil
@@ -205,18 +204,17 @@ class XctestSession(object):
           'XctestSession.Prepare first.')
 
     if self._xctestrun_obj:
+      result_bundle_path = os.path.join(
+        os.environ['TEST_UNDECLARED_OUTPUTS_DIR'], 'test.xcresult')
       exit_code = self._xctestrun_obj.Run(device_id, self._sdk,
                                           self._output_dir,
                                           self._startup_timeout_sec,
                                           self._destination_timeout_sec,
-                                          os_version=os_version)
+                                          os_version=os_version,
+                                          result_bundle_path=result_bundle_path)
       # The xcresult only contains raw data in Xcode 11 or later.
       if xcode_info_util.GetXcodeVersionNumber() >= 1100:
-        test_log_dir = '%s/Logs/Test' % self._output_dir
-        xcresults = glob.glob('%s/*.xcresult' % test_log_dir)
-        for xcresult in xcresults:
-          xcresult_util.ExposeDiagnosticsRef(xcresult, test_log_dir)
-          shutil.rmtree(xcresult)
+        xcresult_util.ExposeDiagnosticsRef(result_bundle_path, test_log_dir)
       return exit_code
     elif self._logic_test_bundle:
       return logic_test_util.RunLogicTestOnSim(

--- a/xctestrunner/test_runner/xctest_session.py
+++ b/xctestrunner/test_runner/xctest_session.py
@@ -204,8 +204,7 @@ class XctestSession(object):
           'XctestSession.Prepare first.')
 
     if self._xctestrun_obj:
-      result_bundle_path = os.path.join(
-        os.environ['TEST_UNDECLARED_OUTPUTS_DIR'], 'test.xcresult')
+      result_bundle_path = os.path.join(self._output_dir, 'test.xcresult')
       exit_code = self._xctestrun_obj.Run(device_id, self._sdk,
                                           self._output_dir,
                                           self._startup_timeout_sec,


### PR DESCRIPTION
This outputs the xcresult bundle to a specific place, and stops removing
them so they can be consumed after the test