### PR TITLE
Fix: selected tests are not properly running

### DIFF
--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -501,6 +501,7 @@ class XctestRunFactory(object):
         'DYLD_LIBRARY_PATH': '__TESTROOT__:%s/usr/lib' % developer_path
     }
     self._xctestrun_dict = {
+        'ProductModuleName': self._test_name,
         'IsUITestBundle': True,
         'SystemAttachmentLifetime': 'keepNever',
         'TestBundlePath': self._test_bundle_dir,
@@ -658,6 +659,7 @@ class XctestRunFactory(object):
         'DYLD_LIBRARY_PATH': '__TESTROOT__:%s/usr/lib:' % developer_path
     }
     self._xctestrun_dict = {
+        'ProductModuleName': self._test_name,
         'TestHostPath': self._app_under_test_dir,
         'TestBundlePath': self._test_bundle_dir,
         'IsAppHostedTestBundle': True,
@@ -678,6 +680,7 @@ class XctestRunFactory(object):
         'DYLD_LIBRARY_PATH': dyld_framework_path
     }
     self._xctestrun_dict = {
+        'ProductModuleName': self._test_name,
         'TestBundlePath': self._test_bundle_dir,
         'TestHostPath': xcode_info_util.GetXctestToolPath(self._sdk),
         'TestingEnvironmentVariables': test_envs,


### PR DESCRIPTION
Fixes https://github.com/google/xctestrunner/issues/25.

As the `ProductModuleName` entry was absent from the generated `xctestrun.plist`, selected tests are not picked up to run despite being specified in the `OnlyTestIdentifiers` entry.