### PR TITLE
Avoid crashing if activitySummaries is missing from the .xcresult

### DIFF
--- a/test_runner/xcresult_util.py
+++ b/test_runner/xcresult_util.py
@@ -21,7 +21,7 @@ import subprocess
 from xctestrunner.shared import ios_errors
 
 
-def ExpoesXcresult(xcresult_path, output_path):
+def ExposeXcresult(xcresult_path, output_path):
   """Exposes the files from xcresult.
 
   The files includes the diagnostics files and attachments files.

--- a/test_runner/xcresult_util.py
+++ b/test_runner/xcresult_util.py
@@ -72,6 +72,11 @@ def _ExposeAttachments(xcresult_path, output_path, action_result):
   failure_test_ref_ids = _GetFailureTestRefs(root_tests_summary)
   for test_ref_id in failure_test_ref_ids:
     test_summary_result = _GetResultBundleObject(xcresult_path, test_ref_id)
+    # if the test results in an `expectedFailures` entry, there might be an
+    # `activitySummaries` field present.
+    if 'activitySummaries' not in test_summary_result:
+      continue
+
     activity_summaries = test_summary_result['activitySummaries']['_values']
     for activity_summary in activity_summaries:
       if 'attachments' in activity_summary:

--- a/test_runner/xctest_session.py
+++ b/test_runner/xctest_session.py
@@ -217,7 +217,7 @@ class XctestSession(object):
       if xcode_info_util.GetXcodeVersionNumber() >= 1100:
         expose_xcresult = os.path.join(self._output_dir, 'ExposeXcresult')
         try:
-          xcresult_util.ExpoesXcresult(result_bundle_path, expose_xcresult)
+          xcresult_util.ExposeXcresult(result_bundle_path, expose_xcresult)
           if not self._keep_xcresult_data:
             shutil.rmtree(result_bundle_path)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
If the test suite emits no attachments *and* has an expected failure, the resulting `test_summary_result` might not contain an  `activitySummaries` field. This will lead to `xctestrunner` failing the test suite regardless, by crashing while trying to parse the `.xcresult`:

```
** TEST EXECUTE SUCCEEDED **

2021-10-09 19:35:41,143 Deleting simulator 20C3CEF1-796A-4E2E-8CF8-74BECD3FFBD5 asynchronously.
Traceback (most recent call last):
  File "[redacted]/xctestrunner/test_runner/ios_test_runner.py", line 324, in <module>
    sys.exit(main(sys.argv))
  File "[redacted]/xctestrunner/test_runner/ios_test_runner.py", line 318, in main
    exit_code = args.func(args)
  File "[redacted]/xctestrunner/test_runner/ios_test_runner.py", line 215, in _SimulatorTest
    return _RunSimulatorTest(args)
  File "[redacted]/xctestrunner/test_runner/ios_test_runner.py", line 181, in _RunSimulatorTest
    exit_code = session.RunTest(simulator_id)
  File "[redacted]/xctestrunner/test_runner/xctest_session.py", line 220, in RunTest
    xcresult_util.ExposeXcresult(result_bundle_path, expose_xcresult)
  File "[redacted]/xctestrunner/test_runner/xcresult_util.py", line 45, in ExposeXcresult
    _ExposeAttachments(xcresult_path, output_path, action_result)
  File "[redacted]/xctestrunner/test_runner/xcresult_util.py", line 75, in _ExposeAttachments
    activity_summaries = test_summary_result['activitySummaries']['_values']
KeyError: 'activitySummaries'
```

This PR fixes this issue by skipping attachment retrieval from test summary results that don't contain activity summaries.