### PR TITLE
Switch to using universal_newlines for <3.7 python compatibility

### DIFF
--- a/test_runner/xctest_session.py
+++ b/test_runner/xctest_session.py
@@ -376,7 +376,8 @@ def _DetectTestType(test_bundle_dir):
   """Detects if the test bundle is XCUITest or XCTest."""
   test_bundle_exec_path = os.path.join(
       test_bundle_dir, os.path.splitext(os.path.basename(test_bundle_dir))[0])
-  output = subprocess.check_output(['nm', test_bundle_exec_path], text=True)
+  output = subprocess.check_output(['nm', test_bundle_exec_path],
+      universal_newlines=True)
   if 'XCUIApplication' in output:
     return ios_constants.TestType.XCUITEST
   else:


### PR DESCRIPTION
"text" parameter is introduced in Python 3.7+ and wasn't available in lower versions. Updated here to use the alternative alias "universal_newlines" instead for better compatibility with prior Python versions. 