### PR TITLE
Support running x86_64 logic tests on Apple silicon

### DIFF
--- a/shared/bundle_util.py
+++ b/shared/bundle_util.py
@@ -228,6 +228,10 @@ def RemoveArchType(file_path, arch_type):
   subprocess.check_call(
       ['/usr/bin/lipo', file_path, '-remove', arch_type, '-output', file_path])
 
+def LeaveOnlyArchType(file_path, arch_type):
+  """Remove the other architecture types for the file."""
+  subprocess.check_call(
+      ['/usr/bin/lipo', file_path, '-thin', arch_type, '-output', file_path])
 
 def _ExtractBundleFile(target_dir, bundle_extension):
   """Extract single bundle file with given extension.

--- a/shared/bundle_util.py
+++ b/shared/bundle_util.py
@@ -228,10 +228,10 @@ def RemoveArchType(file_path, arch_type):
   subprocess.check_call(
       ['/usr/bin/lipo', file_path, '-remove', arch_type, '-output', file_path])
 
-def LeaveOnlyArchType(file_path, arch_type):
+def LeaveOnlyArchType(input_file_path, output_file_path, arch_type):
   """Remove the other architecture types for the file."""
   subprocess.check_call(
-      ['/usr/bin/lipo', file_path, '-thin', arch_type, '-output', file_path])
+      ['/usr/bin/lipo', input_file_path, '-thin', arch_type, '-output', output_file_path])
 
 def _ExtractBundleFile(target_dir, bundle_extension):
   """Extract single bundle file with given extension.

--- a/test_runner/logic_test_util.py
+++ b/test_runner/logic_test_util.py
@@ -71,18 +71,19 @@ def RunLogicTestOnSim(sim_id,
   if developer_dir:
     simctl_env_vars['DEVELOPER_DIR'] = developer_dir
 
-  xctest_tool = shutil.copy(
-    xcode_info_util.GetXctestToolPath(ios_constants.SDK.IPHONESIMULATOR),
-    os.path.join(tempfile.mkdtemp(), "xctest")
-  )
+  xctest_tool = os.path.join(tempfile.mkdtemp(), "xctest")
 
   test_bundle_name = os.path.splitext(os.path.basename(test_bundle_path))[0]
   test_executable = os.path.join(test_bundle_path, test_bundle_name)
   test_archs = bundle_util.GetFileArchTypes(test_executable)
   
   # if a logic bundle is built w/ x86 on Apple silicon, it won't be able to launch on the ARM64 sim; rework the xctest to fix this
-  if ios_constants.ARCH.X86_64 in test_archs:
-    bundle_util.LeaveOnlyArchType(xctest_tool, ios_constants.ARCH.X86_64)
+  if ios_constants.ARCH.X86_64 in test_archs and len(test_archs) == 1:
+    bundle_util.LeaveOnlyArchType(
+      xcode_info_util.GetXctestToolPath(ios_constants.SDK.IPHONESIMULATOR),
+      xctest_tool,
+      ios_constants.ARCH.X86_64
+    )
     platform_developer_dir = os.path.join(xcode_info_util.GetSdkPlatformPath(ios_constants.SDK.IPHONESIMULATOR), "Developer")
     simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + "DYLD_FALLBACK_LIBRARY_PATH"] = "{0}/usr/lib".format(platform_developer_dir)
     simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + "DYLD_FALLBACK_FRAMEWORK_PATH"] = "{0}/Library/Frameworks:{0}/Library/Private/Frameworks".format(platform_developer_dir)


### PR DESCRIPTION
This PR adds support for running x86_64 logic tests on Apple silicon by following the patterns introduced in [7f8fc8](https://github.com/google/xctestrunner/commit/7f8fc81b10c8d93f09f6fe38b2a3f37ba25336a6). This is most helpful in the current Bazel/rules_apple context, where the only Simulator binaries produced are x86. This approach to running logic tests on Apple silicon is discussed in MobileNativeFoundation/discussions#141.

Since `xctest` is stripped down to x86 only if the x86 slice is present, this should not affect existing Intel Macs, and should be automatically skipped once rules_apple and Bazel correctly support Apple silicon Simulator.