### PR TITLE
Stop including stderr in simulator output

### DIFF
--- a/shared/ios_constants.py
+++ b/shared/ios_constants.py
@@ -44,8 +44,6 @@ TEST_STARTED_SIGNAL = 'Test Suite'
 XCTRUNNER_STARTED_SIGNAL = 'Running tests...'
 
 CORESIMULATOR_INTERRUPTED_ERROR = 'CoreSimulatorService connection interrupted'
-CORESIMULATOR_CHANGE_ERROR = ('CoreSimulator detected Xcode.app relocation or '
-                              'CoreSimulatorService version change.')
 
 LAUNCH_OPTIONS_JSON_HELP = (
     """The path of json file, which contains options of launching test.

--- a/simulator_control/simulator_util.py
+++ b/simulator_control/simulator_util.py
@@ -715,14 +715,11 @@ def RunSimctlCommand(command):
         stderr=subprocess.PIPE,
         encoding='utf-8')
     stdout, stderr = process.communicate()
-    if ios_constants.CORESIMULATOR_CHANGE_ERROR in stderr:
-      output = stdout
-    else:
-      output = '\n'.join([stdout, stderr])
-    output = output.strip()
+    all_output = '\n'.join([stdout, stderr])
+    output = stdout.strip()
     if process.poll() != 0:
       if (i < (_SIMCTL_MAX_ATTEMPTS - 1) and
-          ios_constants.CORESIMULATOR_INTERRUPTED_ERROR in output):
+          ios_constants.CORESIMULATOR_INTERRUPTED_ERROR in all_output):
         continue
       raise ios_errors.SimError(output)
     return output


### PR DESCRIPTION
On M1 macs running anything with xcrun prints a bunch of these warnings
to stderr (FB9089778):

```
objc[35011]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libauthinstall.dylib (0x1ffc8ab90) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1044502c8). One of the two will be used. Which one is undefined.
```

So capturing this output, and then using it as json, is invalid on M1
machines when this happens. None of the consumers of this function check
the output for any error strings, so this change should only improve the
other use cases.