### PR TITLE
xcuitest copy private frameworks for xcode 13

### DIFF
--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -486,7 +486,22 @@ class XctestRunFactory(object):
           uitest_runner_app,
           entitlements_plist_path=entitlements_plist_path,
           identity=test_bundle_signing_identity)
-
+      if xcode_info_util.GetXcodeVersionNumber() >= 1300:
+        _CopyAndSignFramework(
+            os.path.join(
+                platform_path, 'Developer/Library/PrivateFrameworks/'
+                'XCUIAutomation.framework'),
+            runner_app_frameworks_dir, test_bundle_signing_identity)
+        _CopyAndSignFramework(
+            os.path.join(
+                platform_path, 'Developer/Library/PrivateFrameworks/'
+                'XCTestCore.framework'),
+            runner_app_frameworks_dir, test_bundle_signing_identity)
+        _CopyAndSignFramework(
+            os.path.join(
+                platform_path, 'Developer/Library/PrivateFrameworks/'
+                'XCUnit.framework'),
+            runner_app_frameworks_dir, test_bundle_signing_identity)
       bundle_util.CodesignBundle(self._test_bundle_dir)
       bundle_util.CodesignBundle(self._app_under_test_dir)
 

--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -488,20 +488,17 @@ class XctestRunFactory(object):
           identity=test_bundle_signing_identity)
       if xcode_info_util.GetXcodeVersionNumber() >= 1300:
         _CopyAndSignFramework(
-            os.path.join(
-                platform_path, 'Developer/Library/PrivateFrameworks/'
-                'XCUIAutomation.framework'),
-            runner_app_frameworks_dir, test_bundle_signing_identity)
+          os.path.join(platform_library_path,
+                       'PrivateFrameworks/XCUIAutomation.framework'),
+          runner_app_frameworks_dir, test_bundle_signing_identity)
         _CopyAndSignFramework(
-            os.path.join(
-                platform_path, 'Developer/Library/PrivateFrameworks/'
-                'XCTestCore.framework'),
-            runner_app_frameworks_dir, test_bundle_signing_identity)
+          os.path.join(platform_library_path,
+                       'PrivateFrameworks/XCTestCore.framework'),
+          runner_app_frameworks_dir, test_bundle_signing_identity)
         _CopyAndSignFramework(
-            os.path.join(
-                platform_path, 'Developer/Library/PrivateFrameworks/'
-                'XCUnit.framework'),
-            runner_app_frameworks_dir, test_bundle_signing_identity)
+          os.path.join(platform_library_path,
+                       'PrivateFrameworks/XCUnit.framework'),
+          runner_app_frameworks_dir, test_bundle_signing_identity)
       bundle_util.CodesignBundle(self._test_bundle_dir)
       bundle_util.CodesignBundle(self._app_under_test_dir)
 


### PR DESCRIPTION
Copy the private frameworks, XCUIAutomation, XCTestCore and XCUnit for xcuitest. 

When running a xcuitest on xcode 13.3 
```
/usr/local/bin/ios_test_runner.par --app_under_test_path app.ipa --test_bundle_path app-ui-tests.zip --work_dir ~/app/work --output_dir ~/app/output --verbose --test_type xcuitest test --id fad8dae867f13d3d53a33
```

we get the following error 
```
Testing started
dyld[312]: Library not loaded: @rpath/XCUIAutomation.framework/XCUIAutomation
  Referenced from: /private/var/containers/Bundle/Application/BEA2D04E-F733-4E61-86E9-422EEE445A43/.app/Frameworks/XCTest.framework/XCTest
  Reason: tried: '/Users/fescobedo/fad8dae867f13d3d53a3368c7f871c6465832dd9/work31/TEST_ROOT/XCUIAutomation.framework/XCUIAutomation' 
```

The xcuitest tests run successfully after copying the frameworks. 

Thank you!