### PR TITLE
Add missing dylib for running XCUITest on Xcode 13

### DIFF
--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -482,6 +482,22 @@ class XctestRunFactory(object):
         _CopyAndSignLibFile(
             os.path.join(platform_path, _LIB_XCTEST_SWIFT_RELATIVE_PATH),
             runner_app_frameworks_dir, test_bundle_signing_identity)
+      if xcode_info_util.GetXcodeVersionNumber() >= 1300:
+        _CopyAndSignFramework(
+            os.path.join(
+                platform_path, 'Developer/Library/PrivateFrameworks/'
+                'XCUIAutomation.framework'),
+            runner_app_frameworks_dir, test_bundle_signing_identity)
+        _CopyAndSignFramework(
+            os.path.join(
+                platform_path, 'Developer/Library/PrivateFrameworks/'
+                'XCTestCore.framework'),
+            runner_app_frameworks_dir, test_bundle_signing_identity)
+        _CopyAndSignFramework(
+            os.path.join(
+                platform_path, 'Developer/Library/PrivateFrameworks/'
+                'XCUnit.framework'),
+            runner_app_frameworks_dir, test_bundle_signing_identity)
       bundle_util.CodesignBundle(
           uitest_runner_app,
           entitlements_plist_path=entitlements_plist_path,


### PR DESCRIPTION
running xcuitest with xcrunner on xcode 13 will result in missing XCUIAutomation, XCTestCore and XCUnit

### Detail
<img width="1292" alt="Screen Shot 2022-08-10 at 17 23 49" src="https://user-images.githubusercontent.com/16457495/183879824-0bd2cceb-f084-4c31-b057-781c053eda5c.png">
<img width="1294" alt="Screen Shot 2022-08-10 at 17 22 54" src="https://user-images.githubusercontent.com/16457495/183879848-642c0537-8a03-4a2d-ba9c-8b91252fd3c3.png">
<img width="1289" alt="Screen Shot 2022-08-10 at 17 21 53" src="https://user-images.githubusercontent.com/16457495/183879855-301ceda3-51e0-41f6-9937-f5f0467cfb19.png">

### Solution
I see there has been a fix on unit test side, so add the same implementation for uitest.