### PR TITLE
Remove use of subpar

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@subpar//:subpar.bzl", "par_binary")
-
 py_library(
     name = "shared",
     srcs = glob(["shared/*.py"]),
@@ -15,15 +13,11 @@ py_library(
     ],
 )
 
-par_binary(
+py_binary(
     name = "ios_test_runner",
     srcs = ["__init__.py"] + glob(
         ["test_runner/*.py"],
     ),
-    compiler_args = [
-        "--interpreter",
-        "/usr/bin/python3",
-    ],
     main = "test_runner/ios_test_runner.py",
     python_version = "PY3",
     deps = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,1 @@
 workspace(name = "xctestrunner")
-
-# For packaging python scripts.
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "subpar",
-    remote = "https://github.com/google/subpar",
-    tag = "2.0.0",
-)


### PR DESCRIPTION
This project was recently officially marked as deprecated https://github.com/google/subpar/pull/136

rules_apple has supported referencing non-single-file targets for this use case for a few years, so this drop in replacement as a py_binary seems to work fine.