### PR TITLE
[Xcode 14] Don't collect diagnostics

### DIFF
--- a/xctestrunner/test_runner/xctestrun.py
+++ b/xctestrunner/test_runner/xctestrun.py
@@ -182,6 +182,9 @@ class XctestRun(object):
       shutil.rmtree(result_bundle_path, ignore_errors=True)
       command.extend(['-resultBundlePath', result_bundle_path])
 
+    if xcode_version >= 1410:
+      command.extend(['-collect-test-diagnostics', 'Never'])
+
     if destination_timeout_sec:
       command.extend(['-destination-timeout', str(destination_timeout_sec)])
     exit_code, _ = xcodebuild_test_executor.XcodebuildTestExecutor(


### PR DESCRIPTION
Unless people are explicitly looking at this, it adds more overhead and increases result bundle size.

If someone wants to have this, then perhaps we'd add a flag to have it back but seems like a sensible default