### PR TITLE
Fix __init__.py generation causing wrong sys.path entry to be picked up

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,7 +15,7 @@ py_library(
 
 py_binary(
     name = "ios_test_runner",
-    srcs = ["xctestrunner/__init__.py"] + glob(
+    srcs = ["__init__.py", "xctestrunner/__init__.py"] + glob(
         ["xctestrunner/test_runner/*.py"],
     ),
     main = "xctestrunner/test_runner/ios_test_runner.py",

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+import sys
+from . import xctestrunner
+sys.modules['xctestrunner'] = xctestrunner

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,7 @@
+# This file is just here to work around Bazel auto-generating an empty file here.
+# What happens is `import xctestrunner` loads this file instead of the
+# subdirectory because the root runfiles directory comes before the subdirectory
+# on sys.path
 import sys
 from . import xctestrunner
 sys.modules['xctestrunner'] = xctestrunner


### PR DESCRIPTION
This is a fix for an issue caused by the implicit `__init__.py` that caused imports to fail like this after https://github.com/google/xctestrunner/pull/47: 
```
    from xctestrunner.shared import ios_constants
ModuleNotFoundError: No module named 'xctestrunner.shared'
```
More details in this Bazel Slack thread: https://bazelbuild.slack.com/archives/CA306CEV6/p1676039283187729