### PR TITLE
Fix -collect-test-diagnostics arg for Xcode 14.1 / 14.2

### DIFF
--- a/xctestrunner/test_runner/xctestrun.py
+++ b/xctestrunner/test_runner/xctestrun.py
@@ -183,7 +183,7 @@ class XctestRun(object):
       command.extend(['-resultBundlePath', result_bundle_path])
 
     if xcode_version >= 1410:
-      command.extend(['-collect-test-diagnostics', 'Never'])
+      command.extend(['-collect-test-diagnostics=never'])
 
     if destination_timeout_sec:
       command.extend(['-destination-timeout', str(destination_timeout_sec)])


### PR DESCRIPTION
Seems like Xcode 14.1 and 14.2 require an equals sign here, otherwise they fail with:

```
xcodebuild: error: option -collect-test-diagnostics requires one of two values: on-failure or never
```

Xcode 14.3 seems to have fixed this.