### PR TITLE
Update path to DeviceTypes for Xcode 16.3

### DIFF
--- a/xctestrunner/simulator_control/simtype_profile.py
+++ b/xctestrunner/simulator_control/simtype_profile.py
@@ -50,7 +50,9 @@ class SimTypeProfile(object):
       xcode_version = xcode_info_util.GetXcodeVersionNumber()
       platform_path = xcode_info_util.GetSdkPlatformPath(
           ios_constants.SDK.IPHONEOS)
-      if xcode_version >= 1100:
+      if xcode_version >= 1630:
+        sim_profiles_dir = '/Library/Developer/CoreSimulator/Profiles'
+      elif xcode_version >= 1100:
         sim_profiles_dir = os.path.join(
             platform_path, 'Library/Developer/CoreSimulator/Profiles')
       else:


### PR DESCRIPTION
Starting with Xcode 16.3, the simulator device type (.simdevicetype) dirs are no longer shipped with Xcode itself.
```sh
FileNotFoundError: [Errno 2] No such file or directory: '/Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 16.simdevicetype/Contents/Resources/profile.plist'
```
Instead, the test runner should look for .simdevicetype dirs in `/Library/Developer/CoreSimulator/Profiles` for Xcode 16.3 and newer.