### PR TITLE
Update sim profiles directory to handle Xcode 16.3

### DIFF
--- a/xctestrunner/simulator_control/simtype_profile.py
+++ b/xctestrunner/simulator_control/simtype_profile.py
@@ -51,18 +51,17 @@ class SimTypeProfile(object):
       platform_path = xcode_info_util.GetSdkPlatformPath(
           ios_constants.SDK.IPHONEOS)
       if xcode_version >= 1630:
-        profile_plist_path = '/Library/Developer/CoreSimulator/Profiles/DeviceTypes/%s.simdevicetype/Contents/Resources/profile.plist' % self._device_type
+        sim_profiles_dir = '/Library/Developer/CoreSimulator/Profiles'
+      elif xcode_version >= 1100:
+        sim_profiles_dir = os.path.join(
+            platform_path, 'Library/Developer/CoreSimulator/Profiles')
       else:
-        if xcode_version >= 1100:
-          sim_profiles_dir = os.path.join(
-              platform_path, 'Library/Developer/CoreSimulator/Profiles')
-        else:
-          sim_profiles_dir = os.path.join(
-              platform_path, 'Developer/Library/CoreSimulator/Profiles')
-        profile_plist_path = os.path.join(
-            sim_profiles_dir,
-            'DeviceTypes/%s.simdevicetype/Contents/Resources/profile.plist' %
-            self._device_type)
+        sim_profiles_dir = os.path.join(
+            platform_path, 'Developer/Library/CoreSimulator/Profiles')
+      profile_plist_path = os.path.join(
+          sim_profiles_dir,
+          'DeviceTypes/%s.simdevicetype/Contents/Resources/profile.plist' %
+          self._device_type)
       self._profile_plist_obj = plist_util.Plist(profile_plist_path)
     return self._profile_plist_obj
 

--- a/xctestrunner/simulator_control/simtype_profile.py
+++ b/xctestrunner/simulator_control/simtype_profile.py
@@ -50,6 +50,9 @@ class SimTypeProfile(object):
       xcode_version = xcode_info_util.GetXcodeVersionNumber()
       platform_path = xcode_info_util.GetSdkPlatformPath(
           ios_constants.SDK.IPHONEOS)
+      if xcode_version >= 1630:
+        sim_profiles_dir = os.path.join(
+            platform_path, 'Developer/Library/CoreSimulator/Profiles')
       if xcode_version >= 1100:
         sim_profiles_dir = os.path.join(
             platform_path, 'Library/Developer/CoreSimulator/Profiles')

--- a/xctestrunner/simulator_control/simtype_profile.py
+++ b/xctestrunner/simulator_control/simtype_profile.py
@@ -51,18 +51,18 @@ class SimTypeProfile(object):
       platform_path = xcode_info_util.GetSdkPlatformPath(
           ios_constants.SDK.IPHONEOS)
       if xcode_version >= 1630:
-        sim_profiles_dir = os.path.join(
-            platform_path, 'Developer/Library/CoreSimulator/Profiles')
-      if xcode_version >= 1100:
-        sim_profiles_dir = os.path.join(
-            platform_path, 'Library/Developer/CoreSimulator/Profiles')
+        profile_plist_path = '/Library/Developer/CoreSimulator/Profiles/DeviceTypes/%s.simdevicetype/Contents/Resources/profile.plist' % self._device_type
       else:
-        sim_profiles_dir = os.path.join(
-            platform_path, 'Developer/Library/CoreSimulator/Profiles')
-      profile_plist_path = os.path.join(
-          sim_profiles_dir,
-          'DeviceTypes/%s.simdevicetype/Contents/Resources/profile.plist' %
-          self._device_type)
+        if xcode_version >= 1100:
+          sim_profiles_dir = os.path.join(
+              platform_path, 'Library/Developer/CoreSimulator/Profiles')
+        else:
+          sim_profiles_dir = os.path.join(
+              platform_path, 'Developer/Library/CoreSimulator/Profiles')
+        profile_plist_path = os.path.join(
+            sim_profiles_dir,
+            'DeviceTypes/%s.simdevicetype/Contents/Resources/profile.plist' %
+            self._device_type)
       self._profile_plist_obj = plist_util.Plist(profile_plist_path)
     return self._profile_plist_obj
 


### PR DESCRIPTION
Xcode 16.2 example:
```
$ ls -l /Applications/Xcode_16.2.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes
drwxr-xr-x@ 3 mattrob  staff  96 Nov 11 04:06 iPad (10th generation).simdevicetype
drwxr-xr-x@ 3 mattrob  staff  96 Nov 11 04:06 iPad (5th generation).simdevicetype
drwxr-xr-x@ 3 mattrob  staff  96 Nov 11 04:06 iPad (6th generation).simdevicetype
drwxr-xr-x@ 3 mattrob  staff  96 Nov 11 04:06 iPad (7th generation).simdevicetype
drwxr-xr-x@ 3 mattrob  staff  96 Nov 11 04:06 iPad (8th generation).simdevicetype
drwxr-xr-x@ 3 mattrob  staff  96 Nov 11 04:06 iPad (9th generation).simdevicetype
```

Xcode 16.3 example:
```
$ ls -l /Library/Developer/CoreSimulator/Profiles/DeviceTypes
drwxr-xr-x  3 root  admin  96 Nov 11 04:07 Apple TV 4K (2nd generation) (at 1080p).simdevicetype
drwxr-xr-x  3 root  admin  96 Nov 11 04:07 Apple TV 4K (2nd generation).simdevicetype
drwxr-xr-x  3 root  admin  96 Nov 11 04:07 Apple TV 4K (3rd generation) (at 1080p).simdevicetype
drwxr-xr-x  3 root  admin  96 Nov 11 04:07 Apple TV 4K (3rd generation).simdevicetype
drwxr-xr-x  3 root  admin  96 Nov 11 04:07 Apple TV 4K (at 1080p).simdevicetype
drwxr-xr-x  3 root  admin  96 Nov 11 04:07 Apple TV 4K.simdevicetype
...
```