### PR TITLE
Fix GetLastSupportedIphoneSimType to prevent iPhone 6s Plus fallback for modern iOS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,7 +9,12 @@ py_library(
 
 py_library(
     name = "simulator",
-    srcs = glob(["xctestrunner/simulator_control/*.py"]),
+    srcs = glob(
+        ["xctestrunner/simulator_control/*.py"],
+        exclude = [
+            "xctestrunner/simulator_control/test_*.py",
+        ],
+    ),
     deps = [
         ":shared",
     ],
@@ -24,6 +29,17 @@ py_binary(
         ["xctestrunner/test_runner/*.py"],
     ),
     main = "xctestrunner/test_runner/ios_test_runner.py",
+    python_version = "PY3",
+    deps = [
+        ":shared",
+        ":simulator",
+    ],
+)
+
+py_test(
+    name = "simulator_util_test",
+    srcs = ["xctestrunner/simulator_control/test_simulator_util.py"],
+    main = "xctestrunner/simulator_control/test_simulator_util.py",
     python_version = "PY3",
     deps = [
         ":shared",

--- a/xctestrunner/simulator_control/simulator_util.py
+++ b/xctestrunner/simulator_control/simulator_util.py
@@ -437,28 +437,47 @@ def GetSupportedSimDeviceTypes(os_type=None):
 
 
 def GetLastSupportedIphoneSimType(os_version):
-  """"Gets the last supported iPhone simulator type of the given OS version.
+  """Gets the newest iPhone simulator type compatible with the given iOS version.
 
-  Currently, the last supported iPhone simulator type is the last iPhone from
-  the output of `xcrun simctl list devicetypes`.
+  This function returns the most recent iPhone simulator model that can run the
+  specified iOS version. It checks both the minimum and maximum iOS version
+  compatibility for each iPhone model to ensure the returned device can actually
+  run the requested iOS version.
+
+  The function iterates through iPhone simulator types in newest-to-oldest order
+  (as returned by `xcrun simctl list devicetypes`) and returns the first model
+  that satisfies both:
+  - ios_version >= device's minimum supported iOS version
+  - ios_version <= device's maximum supported iOS version (if any)
 
   Args:
-    os_version: string, OS version of the new simulator. The format is
-      {major}.{minor}, such as 9.3, 10.2.
+    os_version: string, OS version to check compatibility against. The format is
+      {major}.{minor}, such as 9.3, 16.0, 18.5.
 
   Returns:
-    a string, the last supported iPhone simulator type.
+    a string, the newest iPhone simulator type compatible with the given iOS
+    version. For example, "iPhone 16 Pro" for iOS 18.5, or "iPhone 13 Pro"
+    for iOS 15.0.
 
   Raises:
-    ios_errors.SimError: when there is no supported iPhone simulator type.
+    ios_errors.SimError: when there is no iPhone simulator type that supports
+        the given iOS version.
+
+  Example:
+    >>> GetLastSupportedIphoneSimType("18.5")
+    "iPhone 16 Pro"
+    >>> GetLastSupportedIphoneSimType("14.0")
+    "iPhone SE (2nd generation)"
   """
   supported_sim_types = GetSupportedSimDeviceTypes(ios_constants.OS.IOS)
-  supported_sim_types.reverse()
   os_version_float = float(os_version)
   for sim_type in supported_sim_types:
     if sim_type.startswith('iPhone'):
-      min_os_version = simtype_profile.SimTypeProfile(sim_type).min_os_version
-      if os_version_float >= min_os_version:
+      sim_profile = simtype_profile.SimTypeProfile(sim_type)
+      min_os_version = sim_profile.min_os_version
+      max_os_version = sim_profile.max_os_version
+      if (os_version_float >= min_os_version and
+          (max_os_version is None or os_version_float <= max_os_version)):
         return sim_type
   raise ios_errors.SimError('Can not find supported iPhone simulator type.')
 

--- a/xctestrunner/simulator_control/test_simulator_util.py
+++ b/xctestrunner/simulator_control/test_simulator_util.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Unit tests for simulator_util.py functions using mocked dependencies.
+"""
+
+import unittest
+from unittest import mock
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from xctestrunner.simulator_control import simulator_util
+from xctestrunner.shared import ios_errors
+
+
+class MockSimTypeProfile:
+    """Mock SimTypeProfile for testing with guaranteed ordering."""
+    
+    def __init__(self, device_type):
+        self.device_type = device_type
+        # Use array of tuples for guaranteed ordering (device, min_os, max_os)
+        # None for max_os means no upper limit
+        self._device_specs = [
+            ('iPhone 16 Pro', 18.0, None),
+            ('iPhone 16', 18.0, None),
+            ('iPhone 15 Pro', 17.0, None),
+            ('iPhone 15', 17.0, None),
+            ('iPhone 14 Pro', 16.0, None),
+            ('iPhone 14', 16.0, None),
+            ('iPhone 13 Pro', 15.0, None),
+            ('iPhone 13', 15.0, None),
+            ('iPhone SE (3rd generation)', 15.4, None),
+            ('iPhone 12 Pro', 14.1, None),
+            ('iPhone 12', 14.1, None),
+            ('iPhone SE (2nd generation)', 13.4, None),
+            ('iPhone 11 Pro', 13.0, None),
+            ('iPhone 11', 13.0, None),
+            ('iPhone Xs', 12.0, 16.99),
+            ('iPhone X', 11.0, 16.99),
+            ('iPhone 8', 11.0, 16.99),
+            ('iPhone 7', 10.0, 15.99),
+            ('iPhone SE (1st generation)', 9.3, 15.99),
+            ('iPhone 6s', 9.0, 15.99),
+            ('iPhone 6s Plus', 9.0, 15.99),
+        ]
+    
+    def _get_device_spec(self):
+        for device, min_os, max_os in self._device_specs:
+            if device == self.device_type:
+                return min_os, max_os
+        return 9.0, None
+    
+    @property
+    def min_os_version(self):
+        min_os, _ = self._get_device_spec()
+        return min_os
+    
+    @property
+    def max_os_version(self):
+        _, max_os = self._get_device_spec()
+        return max_os
+
+
+class TestGetLastSupportedIphoneSimType(unittest.TestCase):
+    """Test cases for GetLastSupportedIphoneSimType function with mocking."""
+
+    def setUp(self):
+        """Set up mock data for consistent testing."""
+        self.mock_devices = [
+            'iPhone 16 Pro', 'iPhone 16', 'iPhone 15 Pro', 'iPhone 15',
+            'iPhone 14 Pro', 'iPhone 14', 'iPhone 13 Pro', 'iPhone 13',
+            'iPhone SE (3rd generation)', 'iPhone 12 Pro', 'iPhone 12',
+            'iPhone SE (2nd generation)', 'iPhone 11 Pro', 'iPhone 11',
+            'iPhone Xs', 'iPhone X', 'iPhone 8', 'iPhone 7',
+            'iPhone SE (1st generation)', 'iPhone 6s', 'iPhone 6s Plus',
+            # Also include non-iPhone devices to test filtering
+            'iPad Pro', 'iPad Air', 'Apple Watch Series 9'
+        ]
+
+    @mock.patch('xctestrunner.simulator_control.simtype_profile.SimTypeProfile')
+    @mock.patch('xctestrunner.simulator_control.simulator_util.GetSupportedSimDeviceTypes')
+    def test_ios_18_5_returns_newest_compatible(self, mock_get_devices, mock_profile):
+        """Test iOS 18.5 returns newest iPhone that supports it."""
+        mock_get_devices.return_value = self.mock_devices
+        mock_profile.side_effect = MockSimTypeProfile
+        
+        result = simulator_util.GetLastSupportedIphoneSimType("18.5")
+        self.assertEqual(result, "iPhone 16 Pro")
+
+    @mock.patch('xctestrunner.simulator_control.simtype_profile.SimTypeProfile')
+    @mock.patch('xctestrunner.simulator_control.simulator_util.GetSupportedSimDeviceTypes')
+    def test_ios_16_0_respects_max_version(self, mock_get_devices, mock_profile):
+        """Test iOS 16.0 correctly handles max_os_version limits."""
+        mock_get_devices.return_value = self.mock_devices
+        mock_profile.side_effect = MockSimTypeProfile
+        
+        result = simulator_util.GetLastSupportedIphoneSimType("16.0")
+        self.assertEqual(result, "iPhone 14 Pro")
+
+    @mock.patch('xctestrunner.simulator_control.simtype_profile.SimTypeProfile')
+    @mock.patch('xctestrunner.simulator_control.simulator_util.GetSupportedSimDeviceTypes')
+    def test_critical_bug_regression_iphone_6s_plus(self, mock_get_devices, mock_profile):
+        """Regression test: iPhone 6s Plus should NOT be returned for iOS 18.5."""
+        mock_get_devices.return_value = self.mock_devices
+        mock_profile.side_effect = MockSimTypeProfile
+        
+        result = simulator_util.GetLastSupportedIphoneSimType("18.5")
+        
+        # Regression test: iPhone 6s Plus should NOT be returned for iOS 18.5
+        self.assertNotEqual(result, "iPhone 6s Plus",
+                          "iPhone 6s Plus cannot run iOS 18.5 (max OS 15.99)")
+        self.assertEqual(result, "iPhone 16 Pro")
+
+    @mock.patch('xctestrunner.simulator_control.simtype_profile.SimTypeProfile')
+    @mock.patch('xctestrunner.simulator_control.simulator_util.GetSupportedSimDeviceTypes')
+    def test_no_compatible_devices(self, mock_get_devices, mock_profile):
+        """Test when no devices support the requested iOS version."""
+        limited_devices = ['iPhone 6s Plus', 'iPhone 7', 'iPhone X']
+        mock_get_devices.return_value = limited_devices
+        mock_profile.side_effect = MockSimTypeProfile
+        
+        with self.assertRaises(ios_errors.SimError):
+            simulator_util.GetLastSupportedIphoneSimType("25.0")
+
+    @mock.patch('xctestrunner.simulator_control.simtype_profile.SimTypeProfile')
+    @mock.patch('xctestrunner.simulator_control.simulator_util.GetSupportedSimDeviceTypes')
+    def test_no_iphones_available(self, mock_get_devices, mock_profile):
+        """Test when no iPhone simulators are available."""
+        mock_get_devices.return_value = ['iPad Pro', 'iPad Air', 'Apple Watch Series 9']
+        mock_profile.side_effect = MockSimTypeProfile
+        
+        with self.assertRaises(ios_errors.SimError):
+            simulator_util.GetLastSupportedIphoneSimType("16.0")
+
+    def test_invalid_version_format(self):
+        """Test with invalid iOS version format."""
+        with self.assertRaises(ValueError):
+            simulator_util.GetLastSupportedIphoneSimType("invalid")
+        
+        with self.assertRaises(ValueError):
+            simulator_util.GetLastSupportedIphoneSimType("not.a.number")
+
+
+if __name__ == '__main__':    
+    unittest.main()


### PR DESCRIPTION
The GetLastSupportedIphoneSimType function was incorrectly returning iPhone 6s Plus
for iOS versions it cannot support (e.g., iOS 18.5), contributing to the broader
issue where outdated iPhone 6s Plus becomes the default simulator device.

Changes:
- Fix compatibility logic to check both min_os_version AND max_os_version
- Remove incorrect .reverse() call that caused oldest-first device ordering
- Update function documentation to reflect correct behavior
- Add mocked tests with regression protection

The iPhone 6s Plus (max iOS 15.99) should never be returned for iOS 18.5+,
preventing downstream tools from defaulting to this obsolete device.

Related: https://github.com/bazelbuild/rules_apple/issues/2773