### PR TITLE
Retry `xcodebuild` by rebooting simulator when stuck

### DIFF
--- a/xctestrunner/test_runner/xcodebuild_test_executor.py
+++ b/xctestrunner/test_runner/xcodebuild_test_executor.py
@@ -211,6 +211,16 @@ class XcodebuildTestExecutor(object):
 
         check_xcodebuild_stuck.Terminate()
         if check_xcodebuild_stuck.is_xcodebuild_stuck:
+          if self._sdk == ios_constants.SDK.IPHONESIMULATOR and i < max_attempts - 1:
+            logging.warning(
+                'xcodebuild stuck on simulator (attempt %d/%d). '
+                'Will reboot simulator and retry.',
+                i + 1, max_attempts)
+            simulator = simulator_util.Simulator(self._device_id)
+            simulator.Shutdown()
+            simulator.Boot()
+            time.sleep(2)
+            continue
           return self._GetResultForXcodebuildStuck(output, return_output)
 
         output_str = output.getvalue()


### PR DESCRIPTION
When `xcodebuild` times out waiting for tests to start, reboot the simulator and retry up to 3 times before failing. This handles intermittent issues where the simulator gets into a bad state.