### PR TITLE
Add explicit load for python rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(
@@ -15,7 +17,10 @@ py_library(
 
 py_binary(
     name = "ios_test_runner",
-    srcs = ["__init__.py", "xctestrunner/__init__.py"] + glob(
+    srcs = [
+        "__init__.py",
+        "xctestrunner/__init__.py",
+    ] + glob(
         ["xctestrunner/test_runner/*.py"],
     ),
     main = "xctestrunner/test_runner/ios_test_runner.py",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,3 +3,5 @@ module(
     version = "0.2.15",
     compatibility_level = 1,
 )
+
+bazel_dep(name = "rules_python", version = "1.0.0")


### PR DESCRIPTION
This is required for bazel @ HEAD and upcoming 9.x
